### PR TITLE
Update jungle-japes-indicator to v1.1

### DIFF
--- a/plugins/jungle-japes-indicator
+++ b/plugins/jungle-japes-indicator
@@ -1,2 +1,2 @@
 repository=https://github.com/TheKlodster/jungle-japes-indicator.git
-commit=0a456fecb41b9a5314fc67a4c78310a8993d503c
+commit=7141265734717376294b6212987f138dc1ce3d08


### PR DESCRIPTION
Fixed the sound not playing when the plugin is distributed as a jar file.